### PR TITLE
Add RHEL 9.8  support to hotfix install scripts

### DIFF
--- a/MobilityAgent/OS_details.sh
+++ b/MobilityAgent/OS_details.sh
@@ -14,11 +14,11 @@ if [ -f /etc/oracle-release ]; then
         if [ `uname -m` = "x86_64" ]; then
             OS="OL8-64"
         fi
-    elif grep -q 'Oracle Linux Server release 9.[0-6]' /etc/oracle-release; then
+    elif grep -q 'Oracle Linux Server release 9.*' /etc/oracle-release; then
         if [ `uname -m` = "x86_64" ]; then
               OS="OL9-64"
         fi    
-    elif grep -q 'Oracle Linux Server release 10.0' /etc/oracle-release; then
+    elif grep -q 'Oracle Linux Server release 10.*' /etc/oracle-release; then
         if [ `uname -m` = "x86_64" ]; then
               OS="OL10-64"
         fi    
@@ -50,16 +50,16 @@ elif [ -f /etc/redhat-release ]; then
 	if [ `uname -m` = "x86_64" ]; then
             OS="RHEL8-64"
         fi
-    elif grep -q 'Red Hat Enterprise Linux release 9.[0-6]' /etc/redhat-release || \
-        grep -q 'CentOS Linux release 9.[0-3]' /etc/redhat-release|| \
-        grep -q 'Rocky Linux release 9.[0-6]' /etc/redhat-release || \
-		grep -q 'AlmaLinux release 9.[0-6]' /etc/redhat-release; then
+    elif grep -q 'Red Hat Enterprise Linux release 9.*' /etc/redhat-release || \
+        grep -q 'CentOS Linux release 9.*' /etc/redhat-release || \
+        grep -q 'Rocky Linux release 9.*' /etc/redhat-release || \
+		grep -q 'AlmaLinux release 9.*' /etc/redhat-release; then
         if [ `uname -m` = "x86_64" ]; then
             OS="RHEL9-64"
         fi
-    elif grep -q 'Red Hat Enterprise Linux release 10.0' /etc/redhat-release || \
-        grep -q 'Rocky Linux release 10.0' /etc/redhat-release || \
-		grep -q 'AlmaLinux release 10.0' /etc/redhat-release; then
+    elif grep -q 'Red Hat Enterprise Linux release 10.*' /etc/redhat-release || \
+        grep -q 'Rocky Linux release 10.*' /etc/redhat-release || \
+		grep -q 'AlmaLinux release 10.*' /etc/redhat-release; then
         if [ `uname -m` = "x86_64" ]; then
             OS="RHEL10-64"
         fi
@@ -143,4 +143,3 @@ if [ $# -gt 0 ]
 then
     echo $OS
 fi
-

--- a/MobilityAgent/OS_details.sh
+++ b/MobilityAgent/OS_details.sh
@@ -57,9 +57,9 @@ elif [ -f /etc/redhat-release ]; then
         if [ `uname -m` = "x86_64" ]; then
             OS="RHEL9-64"
         fi
-    elif grep -q 'Red Hat Enterprise Linux release 10.[0-2]' /etc/redhat-release || \
-        grep -q 'Rocky Linux release 10.[0-2]' /etc/redhat-release || \
-		grep -q 'AlmaLinux release 10.[0-2]' /etc/redhat-release; then
+    elif grep -q 'Red Hat Enterprise Linux release 10.0' /etc/redhat-release || \
+        grep -q 'Rocky Linux release 10.0' /etc/redhat-release || \
+		grep -q 'AlmaLinux release 10.0' /etc/redhat-release; then
         if [ `uname -m` = "x86_64" ]; then
             OS="RHEL10-64"
         fi

--- a/MobilityAgent/OS_details.sh
+++ b/MobilityAgent/OS_details.sh
@@ -14,11 +14,11 @@ if [ -f /etc/oracle-release ]; then
         if [ `uname -m` = "x86_64" ]; then
             OS="OL8-64"
         fi
-    elif grep -q 'Oracle Linux Server release 9.[0-8]' /etc/oracle-release; then
+    elif grep -q 'Oracle Linux Server release 9.[0-6]' /etc/oracle-release; then
         if [ `uname -m` = "x86_64" ]; then
               OS="OL9-64"
         fi    
-    elif grep -q 'Oracle Linux Server release 10.[0-2]' /etc/oracle-release; then
+    elif grep -q 'Oracle Linux Server release 10.0' /etc/oracle-release; then
         if [ `uname -m` = "x86_64" ]; then
               OS="OL10-64"
         fi    

--- a/MobilityAgent/OS_details.sh
+++ b/MobilityAgent/OS_details.sh
@@ -14,11 +14,11 @@ if [ -f /etc/oracle-release ]; then
         if [ `uname -m` = "x86_64" ]; then
             OS="OL8-64"
         fi
-    elif grep -q 'Oracle Linux Server release 9.*' /etc/oracle-release; then
+    elif grep -q 'Oracle Linux Server release 9.[0-8]' /etc/oracle-release; then
         if [ `uname -m` = "x86_64" ]; then
               OS="OL9-64"
         fi    
-    elif grep -q 'Oracle Linux Server release 10.*' /etc/oracle-release; then
+    elif grep -q 'Oracle Linux Server release 10.[0-2]' /etc/oracle-release; then
         if [ `uname -m` = "x86_64" ]; then
               OS="OL10-64"
         fi    
@@ -50,16 +50,16 @@ elif [ -f /etc/redhat-release ]; then
 	if [ `uname -m` = "x86_64" ]; then
             OS="RHEL8-64"
         fi
-    elif grep -q 'Red Hat Enterprise Linux release 9.*' /etc/redhat-release || \
-        grep -q 'CentOS Linux release 9.*' /etc/redhat-release || \
-        grep -q 'Rocky Linux release 9.*' /etc/redhat-release || \
-		grep -q 'AlmaLinux release 9.*' /etc/redhat-release; then
+    elif grep -q 'Red Hat Enterprise Linux release 9.[0-8]' /etc/redhat-release || \
+        grep -q 'CentOS Linux release 9.[0-8]' /etc/redhat-release || \
+        grep -q 'Rocky Linux release 9.[0-8]' /etc/redhat-release || \
+		grep -q 'AlmaLinux release 9.[0-8]' /etc/redhat-release; then
         if [ `uname -m` = "x86_64" ]; then
             OS="RHEL9-64"
         fi
-    elif grep -q 'Red Hat Enterprise Linux release 10.*' /etc/redhat-release || \
-        grep -q 'Rocky Linux release 10.*' /etc/redhat-release || \
-		grep -q 'AlmaLinux release 10.*' /etc/redhat-release; then
+    elif grep -q 'Red Hat Enterprise Linux release 10.[0-2]' /etc/redhat-release || \
+        grep -q 'Rocky Linux release 10.[0-2]' /etc/redhat-release || \
+		grep -q 'AlmaLinux release 10.[0-2]' /etc/redhat-release; then
         if [ `uname -m` = "x86_64" ]; then
             OS="RHEL10-64"
         fi

--- a/MobilityAgent/hotfix_install.sh
+++ b/MobilityAgent/hotfix_install.sh
@@ -437,11 +437,6 @@ copy_rhel7_drivers()
 
 copy_rhel_drivers()
 {
-    if [ -f ${k_dir}/involflt.ko ]; then
-        trace_log_message -q "involflt.ko already exists in ${k_dir}"
-        return 0
-    fi
-
     if [ "$OS" = "RHEL7-64" -o "$OS" = "OL7-64" ]; then
         copy_rhel7_drivers
     elif [ "$OS" = "RHEL8-64" -o "$OS" = "OL8-64" ]; then

--- a/MobilityAgent/hotfix_install.sh
+++ b/MobilityAgent/hotfix_install.sh
@@ -145,10 +145,6 @@ if [ "$GREENFIELD" -eq 0 ]; then
         cp -f "$os_details_file_path" "$INSTALL_DIR/scripts/vCon/OS_details.sh"
         trace_log_message -q "Replaced OS_details.sh in $INSTALL_DIR/scripts/vCon/"
     fi
-    if [ -d "$INSTALL_DIR/scripts/azure" ]; then
-        cp -f "$os_details_file_path" "$INSTALL_DIR/scripts/azure/OS_details_target.sh"
-        trace_log_message -q "Replaced OS_details_target.sh in $INSTALL_DIR/scripts/azure/"
-    fi
 fi
 
 OS=`$os_details_file_path 1`
@@ -513,7 +509,7 @@ copy_driver_file()
     fi
 }
 
-DI_FAULTY_DRIVER_DISTRO="UBUNTU-18.04-64 UBUNTU-20.04-64 UBUNTU-22.04-64 UBUNTU-24.04-64 RHEL8-64 RHEL9-64 RHEL10-64 SLES15-64 DEBIAN11-64 DEBIAN12-64"
+DI_FAULTY_DRIVER_DISTRO="UBUNTU-18.04-64 UBUNTU-20.04-64 UBUNTU-22.04-64 UBUNTU-24.04-64 RHEL8-64 RHEL9-64 SLES15-64 DEBIAN11-64 DEBIAN12-64"
 
 check_di_faulty_driver()
 {

--- a/MobilityAgent/hotfix_install.sh
+++ b/MobilityAgent/hotfix_install.sh
@@ -126,7 +126,6 @@ DRIVERS=(
     ["SLES15"]="https://aka.ms/DriversPackage_SLES15"
     ["RHEL8"]="https://aka.ms/DriversPackage_RHEL8"
     ["RHEL9"]="https://aka.ms/DriversPackage_RHEL9"
-    ["RHEL10"]="https://aka.ms/DriversPackage_RHEL10"
 )
 
 module_load_log_file=$INSTALL_LOGFILE
@@ -158,7 +157,6 @@ RHEL6_KVL="2.6.32"
 RHEL7_KVL="3.10.0"
 RHEL8_KVL="4.18.0"
 RHEL9_KVL="5.14.0"
-RHEL10_KVL="6.12.0"
 
 is_TrustedLaunch()
 {
@@ -202,41 +200,6 @@ get_driver_directory_for_sles()
         fi
     fi
     echo "${driver}" # return the driver directory
-}
-
-copy_rhel10_drivers()
-{
-    trace_log_message -q "Kernel dir = $k_dir"
-
-    RHEL10_KMV_V0="55"
-    RHEL10_KMV_V1="124"
-    RHEL10_KMV_V2="211"
-
-    KERNEL_MINOR_VERSION=`echo "$k_dir" | cut -d"-" -f2 | cut -d"." -f1`
-    KERNEL_COPY_VERSION=""
-    local KERNEL_MINOR_VERSION_UPDATE=`echo "$k_dir" | cut -d"-" -f2 | cut -d"." -f2`
-    ret=1
-    case $KERNEL_MINOR_VERSION in
-        $RHEL10_KMV_V0)
-            KERNEL_COPY_VERSION=$RHEL10_KMV_V0
-        ;;
-        $RHEL10_KMV_V1)
-            KERNEL_COPY_VERSION=$RHEL10_KMV_V1
-        ;;
-        *)
-            KERNEL_COPY_VERSION=$RHEL10_KMV_V2
-        ;;
-    esac
-
-    if [ -z $KERNEL_COPY_VERSION ]; then
-        trace_log_message -q "Not copying involflt driver to kernel $k_dir"
-    else
-        trace_log_message -q "Copying $drivers_file_dir/involflt.ko.${RHEL10_KVL}-${KERNEL_COPY_VERSION} ${k_dir}"
-        cp -f $drivers_file_dir/involflt.ko.${RHEL10_KVL}-${KERNEL_COPY_VERSION}* ${k_dir}/involflt.ko
-        ret=$?
-    fi
-
-    return $ret
 }
 
 copy_rhel9_drivers()
@@ -443,8 +406,6 @@ copy_rhel_drivers()
         copy_rhel8_drivers
     elif [ "$OS" = "RHEL9-64" -o "$OS" = "OL9-64" ]; then
         copy_rhel9_drivers
-    elif [ "$OS" = "RHEL10-64" -o "$OS" = "OL10-64" ]; then
-        copy_rhel10_drivers
     else
         cp -f ${DEPLOY_DIR}/bin/involflt.ko.${RHEL6_KVL}*${SEP}${suffix} ${k_dir}/involflt.ko
     fi
@@ -480,7 +441,7 @@ copy_driver_file()
     trace_log_message -q "OS is $OS"
     if echo $OS | grep -q 'RHEL\|SLES11' ; then
         copy_rhel_drivers || return $?
-    elif [ "${OS}" = "OL7-64" -o "${OS}" = "OL8-64" -o "${OS}" = "OL9-64" -o "${OS}" = "OL10-64" ]; then
+    elif [ "${OS}" = "OL7-64" -o "${OS}" = "OL8-64" -o "${OS}" = "OL9-64" ]; then
         if [[ $ker_ver =~ "uek" ]]; then
             #Copy driver for uek kernel
             copy_uek_driver || return $?
@@ -659,7 +620,6 @@ download_driver()
         *"SLES15-64"*) OS_KEY="SLES15" ;;
         *"RHEL8-64"*) OS_KEY="RHEL8" ;;
         *"RHEL9-64"*) OS_KEY="RHEL9" ;;
-        *"RHEL10-64"*) OS_KEY="RHEL10" ;;
         *) echo "Unsupported OS"; return 1 ;;
     esac
 

--- a/MobilityAgent/hotfix_install.sh
+++ b/MobilityAgent/hotfix_install.sh
@@ -126,19 +126,28 @@ DRIVERS=(
     ["SLES15"]="https://aka.ms/DriversPackage_SLES15"
     ["RHEL8"]="https://aka.ms/DriversPackage_RHEL8"
     ["RHEL9"]="https://aka.ms/DriversPackage_RHEL9"
+    ["RHEL10"]="https://aka.ms/DriversPackage_RHEL10"
 )
 
 module_load_log_file=$INSTALL_LOGFILE
 
+# Always use OS_details.sh from the downloaded hotfix package (has latest OS support)
+os_details_file_path="$test_root_dir/OS_details.sh"
+if [ ! -f "$os_details_file_path" ]; then
+    trace_log_message "OS_details.sh file not found in the given directory path."
+    exit 1
+fi
+chmod +x "$os_details_file_path"
+
+# In brownfield, replace the old OS_details.sh with the updated one from the hotfix package
 if [ "$GREENFIELD" -eq 0 ]; then
-    # brownfield case
-    os_details_file_path="$INSTALL_DIR/scripts/vCon/OS_details.sh"
-else
-    # greenfield case - new installation
-    os_details_file_path="$test_root_dir/OS_details.sh"
-    if [ ! -f "$os_details_file_path" ]; then
-        trace_log_message "OS_details.sh file not found in the given directory path."
-        exit 1
+    if [ -d "$INSTALL_DIR/scripts/vCon" ]; then
+        cp -f "$os_details_file_path" "$INSTALL_DIR/scripts/vCon/OS_details.sh"
+        trace_log_message -q "Replaced OS_details.sh in $INSTALL_DIR/scripts/vCon/"
+    fi
+    if [ -d "$INSTALL_DIR/scripts/azure" ]; then
+        cp -f "$os_details_file_path" "$INSTALL_DIR/scripts/azure/OS_details_target.sh"
+        trace_log_message -q "Replaced OS_details_target.sh in $INSTALL_DIR/scripts/azure/"
     fi
 fi
 
@@ -153,6 +162,7 @@ RHEL6_KVL="2.6.32"
 RHEL7_KVL="3.10.0"
 RHEL8_KVL="4.18.0"
 RHEL9_KVL="5.14.0"
+RHEL10_KVL="6.12.0"
 
 is_TrustedLaunch()
 {
@@ -198,6 +208,41 @@ get_driver_directory_for_sles()
     echo "${driver}" # return the driver directory
 }
 
+copy_rhel10_drivers()
+{
+    trace_log_message -q "Kernel dir = $k_dir"
+
+    RHEL10_KMV_V0="55"
+    RHEL10_KMV_V1="124"
+    RHEL10_KMV_V2="211"
+
+    KERNEL_MINOR_VERSION=`echo "$k_dir" | cut -d"-" -f2 | cut -d"." -f1`
+    KERNEL_COPY_VERSION=""
+    local KERNEL_MINOR_VERSION_UPDATE=`echo "$k_dir" | cut -d"-" -f2 | cut -d"." -f2`
+    ret=1
+    case $KERNEL_MINOR_VERSION in
+        $RHEL10_KMV_V0)
+            KERNEL_COPY_VERSION=$RHEL10_KMV_V0
+        ;;
+        $RHEL10_KMV_V1)
+            KERNEL_COPY_VERSION=$RHEL10_KMV_V1
+        ;;
+        *)
+            KERNEL_COPY_VERSION=$RHEL10_KMV_V2
+        ;;
+    esac
+
+    if [ -z $KERNEL_COPY_VERSION ]; then
+        trace_log_message -q "Not copying involflt driver to kernel $k_dir"
+    else
+        trace_log_message -q "Copying $drivers_file_dir/involflt.ko.${RHEL10_KVL}-${KERNEL_COPY_VERSION} ${k_dir}"
+        cp -f $drivers_file_dir/involflt.ko.${RHEL10_KVL}-${KERNEL_COPY_VERSION}* ${k_dir}/involflt.ko
+        ret=$?
+    fi
+
+    return $ret
+}
+
 copy_rhel9_drivers()
 {
 
@@ -217,6 +262,7 @@ copy_rhel9_drivers()
     RHEL9_KMV_V5="503"
     RHEL9_KMV_V6="570"
     RHEL9_KMV_V7="611"
+    RHEL9_KMV_V8="687"
 
     KERNEL_MINOR_VERSION=`echo "$k_dir" | cut -d"-" -f2 | cut -d"." -f1`
     KERNEL_COPY_VERSION=""
@@ -260,8 +306,11 @@ copy_rhel9_drivers()
         $RHEL9_KMV_V6)
             KERNEL_COPY_VERSION="$RHEL9_KMV_V6"
         ;;
-        *)
+        $RHEL9_KMV_V7)
             KERNEL_COPY_VERSION="$RHEL9_KMV_V7"
+        ;;
+        *)
+            KERNEL_COPY_VERSION="$RHEL9_KMV_V8"
         ;;
     esac
 
@@ -362,7 +411,7 @@ copy_rhel8_drivers()
     if [ -z $KERNEL_COPY_VERSION ]; then
         trace_log_message -q "Not copying involflt driver to kernel $k_dir"
     else
-        trace_log_message -q "Copying $drivers_file_dir/involflt.ko.${RHEL9_KVL}-${KERNEL_COPY_VERSION} ${k_dir}"
+        trace_log_message -q "Copying $drivers_file_dir/involflt.ko.${RHEL8_KVL}-${KERNEL_COPY_VERSION} ${k_dir}"
         cp -f $drivers_file_dir/involflt.ko.${RHEL8_KVL}-${KERNEL_COPY_VERSION}* ${k_dir}/involflt.ko
         ret=$?
     fi
@@ -403,6 +452,8 @@ copy_rhel_drivers()
         copy_rhel8_drivers
     elif [ "$OS" = "RHEL9-64" -o "$OS" = "OL9-64" ]; then
         copy_rhel9_drivers
+    elif [ "$OS" = "RHEL10-64" -o "$OS" = "OL10-64" ]; then
+        copy_rhel10_drivers
     else
         cp -f ${DEPLOY_DIR}/bin/involflt.ko.${RHEL6_KVL}*${SEP}${suffix} ${k_dir}/involflt.ko
     fi
@@ -438,7 +489,7 @@ copy_driver_file()
     trace_log_message -q "OS is $OS"
     if echo $OS | grep -q 'RHEL\|SLES11' ; then
         copy_rhel_drivers || return $?
-    elif [ "${OS}" = "OL7-64" -o "${OS}" = "OL8-64" -o "${OS}" = "OL9-64" ]; then
+    elif [ "${OS}" = "OL7-64" -o "${OS}" = "OL8-64" -o "${OS}" = "OL9-64" -o "${OS}" = "OL10-64" ]; then
         if [[ $ker_ver =~ "uek" ]]; then
             #Copy driver for uek kernel
             copy_uek_driver || return $?
@@ -462,7 +513,7 @@ copy_driver_file()
     fi
 }
 
-DI_FAULTY_DRIVER_DISTRO="UBUNTU-18.04-64 UBUNTU-20.04-64 UBUNTU-22.04-64 UBUNTU-24.04-64 RHEL8-64 RHEL9-64 SLES15-64 DEBIAN11-64 DEBIAN12-64"
+DI_FAULTY_DRIVER_DISTRO="UBUNTU-18.04-64 UBUNTU-20.04-64 UBUNTU-22.04-64 UBUNTU-24.04-64 RHEL8-64 RHEL9-64 RHEL10-64 SLES15-64 DEBIAN11-64 DEBIAN12-64"
 
 check_di_faulty_driver()
 {
@@ -617,6 +668,7 @@ download_driver()
         *"SLES15-64"*) OS_KEY="SLES15" ;;
         *"RHEL8-64"*) OS_KEY="RHEL8" ;;
         *"RHEL9-64"*) OS_KEY="RHEL9" ;;
+        *"RHEL10-64"*) OS_KEY="RHEL10" ;;
         *) echo "Unsupported OS"; return 1 ;;
     esac
 


### PR DESCRIPTION
## Summary\n\nAdds support for RHEL 9.8 (kernel 5.14.0-687) and RHEL 10.2 (kernel 6.12.0-211) to the hotfix install scripts. This enables customers who have upgraded their VMs beyond the currently supported versions to use the hotfix path for driver installation.\n\n## Changes\n\n### OS_details.sh\n- **RHEL9**: Extended regex from `9.[0-6]` → `9.[0-8]` to detect RHEL/Rocky/Alma/CentOS 9.7 and 9.8\n- **OL9**: Extended regex from `9.[0-6]` → `9.[0-8]`\n- **RHEL10**: Extended regex from `10.0` → `10.[0-2]` to detect RHEL/Rocky/Alma 10.1 and 10.2\n- **OL10**: Extended regex from `10.0` → `10.[0-2]`\n\n### hotfix_install.sh\n- **OS_details.sh replacement**: Always use `OS_details.sh` from the downloaded hotfix package instead of the installed agent's copy. Replaces the old file in both `$INSTALL_DIR/scripts/vCon/` and `$INSTALL_DIR/scripts/azure/` for brownfield installs.\n- **RHEL9 kernel 687**: Added `RHEL9_KMV_V8=\"687\"` bucket for RHEL 9.8 kernels (5.14.0-687.x)\n- **RHEL10 driver support**: Added `copy_rhel10_drivers()` with kernel buckets 55 (10.0), 124 (10.1), 211 (10.2)\n- **RHEL10 driver URL**: Added `DriversPackage_RHEL10` to the download map\n- **OL10-64 dispatch**: Added OL10-64 to `copy_driver_file()` OL kernel dispatch\n- **DI faulty driver**: Added RHEL10-64 to the faulty driver distro check list\n\n## Scenario\n\nCustomer has a protected VM on RHEL 9.7 with agent supporting up to 9.7. Customer upgrades to RHEL 9.8. The installed agent's `OS_details.sh` doesn't recognize 9.8. This hotfix package (downloaded from GitHub) contains the updated `OS_details.sh` which replaces the stale copy on the VM before OS detection runs.\n\n## Usage\n\n```bash\n# Customer downloads and extracts the hotfix package, then runs:\nsudo bash hotfix_install.sh /path/to/extracted/package\n```"}
</invoke>