### PR TITLE
Fix script download URLs to use raw.githubusercontent.com

### DIFF
--- a/MobilityAgent/KernelModuleDownloadLinks.md
+++ b/MobilityAgent/KernelModuleDownloadLinks.md
@@ -80,8 +80,8 @@ Follow these steps to install the kernel module:
 - Download the following scripts from the ASR GitHub repository:
 
     ```bash
-    # wget https://github.com/Azure/Azure-SiteRecovery/blob/main/MobilityAgent/hotfix_install.sh
-    # wget https://github.com/Azure/Azure-SiteRecovery/blob/main/MobilityAgent/OS_details.sh
+    # wget https://raw.githubusercontent.com/Azure/Azure-SiteRecovery/main/MobilityAgent/hotfix_install.sh
+    # wget https://raw.githubusercontent.com/Azure/Azure-SiteRecovery/main/MobilityAgent/OS_details.sh
     ```
 
 - If the machine does not have internet access, download these scripts on a different machine and transfer them to the impacted machine.
@@ -117,4 +117,3 @@ Follow these steps to install the kernel module:
 - For existing protections, replication will automatically resume.
 
 ---
-


### PR DESCRIPTION
## Summary

Fix the `wget` download URLs in `KernelModuleDownloadLinks.md` to use `raw.githubusercontent.com` so that customers get the actual script content instead of the GitHub HTML page.

## Changes

```diff
-# wget https://github.com/Azure/Azure-SiteRecovery/blob/main/MobilityAgent/hotfix_install.sh
-# wget https://github.com/Azure/Azure-SiteRecovery/blob/main/MobilityAgent/OS_details.sh
+# wget https://raw.githubusercontent.com/Azure/Azure-SiteRecovery/main/MobilityAgent/hotfix_install.sh
+# wget https://raw.githubusercontent.com/Azure/Azure-SiteRecovery/main/MobilityAgent/OS_details.sh
```

## Why `raw.githubusercontent.com` over `?raw=true`

- Avoids the 302 redirect that `?raw=true` triggers
- Standard GitHub convention for direct raw file access
- Simpler URLs for customers to use

Supersedes #28 — thanks to @nick-loader for identifying the issue.

## Tools Used
- GitHub MCP (file read, branch create, commit, PR create)